### PR TITLE
Added «sftp_dir» parameter to server section

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/drone-runners/drone-runner-ssh/command/daemon"
+	"github.com/oxystin/drone-runner-ssh/command/daemon"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/command/compile.go
+++ b/command/compile.go
@@ -11,13 +11,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/drone-runners/drone-runner-ssh/command/internal"
-	"github.com/drone-runners/drone-runner-ssh/engine/compiler"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
 	"github.com/drone/envsubst"
 	"github.com/drone/runner-go/environ"
 	"github.com/drone/runner-go/manifest"
 	"github.com/drone/runner-go/secret"
+	"github.com/oxystin/drone-runner-ssh/command/internal"
+	"github.com/oxystin/drone-runner-ssh/engine/compiler"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
-	"github.com/drone-runners/drone-runner-ssh/internal/match"
-	"github.com/drone-runners/drone-runner-ssh/runtime"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
+	"github.com/oxystin/drone-runner-ssh/internal/match"
+	"github.com/oxystin/drone-runner-ssh/runtime"
 
 	"github.com/drone/runner-go/client"
 	"github.com/drone/runner-go/handler/router"

--- a/command/exec.go
+++ b/command/exec.go
@@ -13,11 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/drone-runners/drone-runner-ssh/command/internal"
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/compiler"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
-	"github.com/drone-runners/drone-runner-ssh/runtime"
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/envsubst"
 	"github.com/drone/runner-go/environ"
@@ -27,6 +22,11 @@ import (
 	"github.com/drone/runner-go/pipeline/console"
 	"github.com/drone/runner-go/secret"
 	"github.com/drone/signal"
+	"github.com/oxystin/drone-runner-ssh/command/internal"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/compiler"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
+	"github.com/oxystin/drone-runner-ssh/runtime"
 
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"

--- a/engine/compiler/compiler_test.go
+++ b/engine/compiler/compiler_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Polyform License
 // that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package compiler
@@ -14,11 +15,11 @@ import (
 	"testing"
 
 	"github.com/dchest/uniuri"
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/runner-go/manifest"
 	"github.com/drone/runner-go/secret"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/engine/compiler/os.go
+++ b/engine/compiler/os.go
@@ -14,13 +14,23 @@ import (
 
 // helper function returns the base temporary directory based
 // on the target platform.
-func tempdir(os string) string {
+func tempdir(os string, root string) (string, string) {
 	dir := fmt.Sprintf("drone-%s", random())
 	switch os {
 	case "windows":
-		return join(os, "C:\\Windows\\Temp", dir)
+		if len(root) > 0 {
+			return join(os, root, "\\Temp", dir), join(os, "\\Temp", dir)
+		} else {
+			path := join(os, "C:\\Windows\\Temp", dir)
+			return path, path
+		}
 	default:
-		return join(os, "/tmp", dir)
+		if len(root) > 0 {
+			return join(os, root, "tmp", dir), join(os, "/tmp", dir)
+		} else {
+			path := join(os, "/tmp", dir)
+			return path, path
+		}
 	}
 }
 

--- a/engine/compiler/os_test.go
+++ b/engine/compiler/os_test.go
@@ -10,38 +10,7 @@ import (
 
 	"github.com/drone/runner-go/shell/bash"
 	"github.com/drone/runner-go/shell/powershell"
-
-	"github.com/dchest/uniuri"
 )
-
-func Test_tempdir(t *testing.T) {
-	// replace the default random function with one that
-	// is deterministic, for testing purposes.
-	random = notRandom
-
-	// restore the default random function and the previously
-	// specified temporary directory
-	defer func() {
-		random = uniuri.New
-	}()
-
-	tests := []struct {
-		os   string
-		path string
-	}{
-		{os: "windows", path: "C:\\Windows\\Temp\\drone-random"},
-		{os: "linux", path: "/tmp/drone-random"},
-		{os: "openbsd", path: "/tmp/drone-random"},
-		{os: "netbsd", path: "/tmp/drone-random"},
-		{os: "freebsd", path: "/tmp/drone-random"},
-	}
-
-	for _, test := range tests {
-		if got, want := tempdir(test.os), test.path; got != want {
-			t.Errorf("Want tempdir %s, got %s", want, got)
-		}
-	}
-}
 
 func Test_join(t *testing.T) {
 	tests := []struct {

--- a/engine/compiler/util.go
+++ b/engine/compiler/util.go
@@ -7,10 +7,10 @@ package compiler
 import (
 	"strings"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/runner-go/manifest"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
 )
 
 // helper function returns true if the step is configured to

--- a/engine/compiler/util_test.go
+++ b/engine/compiler/util_test.go
@@ -7,9 +7,9 @@ package compiler
 import (
 	"testing"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
 	"github.com/drone/runner-go/manifest"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -46,11 +46,11 @@ func (e *engine) Setup(ctx context.Context, spec *Spec) error {
 	// the pipeline workspace is created before pipeline
 	// execution begins. All files and folders created during
 	// pipeline execution are isolated to this workspace.
-	err = mkdir(clientftp, spec.Root, 0777)
+	err = mkdir(clientftp, spec.Sftp, 0777)
 	if err != nil {
 		logger.FromContext(ctx).
 			WithError(err).
-			WithField("path", spec.Root).
+			WithField("path", spec.Sftp).
 			Error("cannot create workspace directory")
 		return err
 	}
@@ -104,23 +104,9 @@ func (e *engine) Destroy(ctx context.Context, spec *Spec) error {
 	}
 	defer client.Close()
 
-	ftp, err := sftp.NewClient(client)
-	if err != nil {
-		return err
-	}
-	defer ftp.Close()
-	if err = ftp.RemoveDirectory(spec.Root); err == nil {
-		return nil
-	}
-
 	// ideally we would remove the directory using sftp, however,
 	// it consistnetly errors on linux and windows. We therefore
 	// fallback to executing ssh commands to remove the directory
-
-	logger.FromContext(ctx).
-		WithError(err).
-		WithField("path", spec.Root).
-		Trace("cannot remove workspace using sftp")
 
 	session, err := client.NewSession()
 	if err != nil {

--- a/engine/replacer/replacer.go
+++ b/engine/replacer/replacer.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine"
 )
 
 const maskedf = "[secret:%s]"

--- a/engine/replacer/replacer_test.go
+++ b/engine/replacer/replacer_test.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine"
 )
 
 func TestReplace(t *testing.T) {

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -43,6 +43,7 @@ type (
 		User     manifest.Variable `json:"user,omitempty"`
 		Password manifest.Variable `json:"password,omitempty"`
 		SSHKey   manifest.Variable `json:"ssh_key,omitempty" yaml:"ssh_key"`
+		SFTPDir  manifest.Variable `json:"sftp_dir,omitempty" yaml:"sftp_dir"`
 	}
 
 	// Step defines a Pipeline step.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -12,6 +12,7 @@ type (
 		Server   Server   `json:"server,omitempty"`
 		Platform Platform `json:"platform,omitempty"`
 		Root     string   `json:"root,omitempty"`
+		Sftp     string   `json:"sftp,omitempty"`
 		Files    []*File  `json:"files,omitempty"`
 		Steps    []*Step  `json:"steps,omitempty"`
 	}
@@ -22,6 +23,7 @@ type (
 		Username string `json:"username,omitempty"`
 		Password string `json:"password,omitempty"`
 		SSHKey   string `json:"ssh_key,omitempty"`
+		SFTPDir  string `json:"sftp_dir,omitempty"`
 	}
 
 	// Step defines a pipeline step.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/drone-runners/drone-runner-ssh
+module github.com/oxystin/drone-runner-ssh
 
 go 1.12
 

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -4,5 +4,5 @@
 
 package mock
 
-//go:generate mockgen -package=mock -destination=mock_engine_gen.go github.com/drone-runners/drone-runner-ssh/engine Engine
-//go:generate mockgen -package=mock -destination=mock_execer_gen.go github.com/drone-runners/drone-runner-ssh/runtime Execer
+//go:generate mockgen -package=mock -destination=mock_engine_gen.go github.com/oxystin/drone-runner-ssh/engine Engine
+//go:generate mockgen -package=mock -destination=mock_execer_gen.go github.com/oxystin/drone-runner-ssh/runtime Execer

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@
 package main
 
 import (
-	"github.com/drone-runners/drone-runner-ssh/command"
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/oxystin/drone-runner-ssh/command"
 )
 
 func main() {

--- a/runtime/execer.go
+++ b/runtime/execer.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/replacer"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/replacer"
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/runner-go/environ"
 	"github.com/drone/runner-go/logger"

--- a/runtime/runner.go
+++ b/runtime/runner.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/drone-runners/drone-runner-ssh/engine"
-	"github.com/drone-runners/drone-runner-ssh/engine/compiler"
-	"github.com/drone-runners/drone-runner-ssh/engine/resource"
+	"github.com/oxystin/drone-runner-ssh/engine"
+	"github.com/oxystin/drone-runner-ssh/engine/compiler"
+	"github.com/oxystin/drone-runner-ssh/engine/resource"
 
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/envsubst"


### PR DESCRIPTION
Added the **«sftp_dir»** parameter to the server section to point to the user's sftp root folder. Example pipeline configuration:

```yaml
kind: pipeline
type: ssh
name: default

server:
  host: 1.2.3.4
  user: admin
  sftp_dir: /home/admin
  password:
    from_secret: password

steps:
- name: greeting
  commands:
  - echo hello world
```

