### PR TITLE
Added «current_dir» parameter to server section

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -114,7 +114,7 @@ func (c *Compiler) Compile(ctx context.Context) *engine.Spec {
 	}
 
 	// create the root directory
-	spec.Root, spec.Sftp = tempdir(os, spec.Server.SFTPDir)
+	spec.Root, spec.Sftp = tempdir(os, spec.Server.SFTPDir, spec.Server.Dir)
 
 	// creates a home directory in the root.
 	// note: mkdirall fails on windows so we need to create all

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -88,6 +88,7 @@ func (c *Compiler) Compile(ctx context.Context) *engine.Spec {
 			Password: c.Pipeline.Server.Password.Value,
 			SSHKey:   c.Pipeline.Server.SSHKey.Value,
 			SFTPDir:  c.Pipeline.Server.SFTPDir.Value,
+			Dir:      c.Pipeline.Server.Dir.Value,
 		},
 	}
 

--- a/engine/compiler/os.go
+++ b/engine/compiler/os.go
@@ -14,21 +14,27 @@ import (
 
 // helper function returns the base temporary directory based
 // on the target platform.
-func tempdir(os string, root string) (string, string) {
-	dir := fmt.Sprintf("drone-%s", random())
+func tempdir(os string, root string, dir string) (string, string) {
+	drone := fmt.Sprintf("drone-%s", random())
+	dir_linux := "tmp"
+	dir_windows := "Temp"
+	if len(dir) > 0 {
+		dir_linux = dir
+		dir_windows = dir
+	}
 	switch os {
 	case "windows":
 		if len(root) > 0 {
-			return join(os, root, "\\Temp", dir), join(os, "\\Temp", dir)
+			return join(os, root, dir_windows, drone), join(os, "", dir_windows, drone)
 		} else {
-			path := join(os, "C:\\Windows\\Temp", dir)
+			path := join(os, "C:", "", "Windows", "", dir_windows, drone)
 			return path, path
 		}
 	default:
 		if len(root) > 0 {
-			return join(os, root, "tmp", dir), join(os, "/tmp", dir)
+			return join(os, root, dir_linux, drone), join(os, "", dir_linux, drone)
 		} else {
-			path := join(os, "/tmp", dir)
+			path := join(os, "", dir_linux, drone)
 			return path, path
 		}
 	}

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -44,6 +44,7 @@ type (
 		Password manifest.Variable `json:"password,omitempty"`
 		SSHKey   manifest.Variable `json:"ssh_key,omitempty" yaml:"ssh_key"`
 		SFTPDir  manifest.Variable `json:"sftp_dir,omitempty" yaml:"sftp_dir"`
+		Dir      manifest.Variable `json:"current_dir,omitempty" yaml:"current_dir"`
 	}
 
 	// Step defines a Pipeline step.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -24,6 +24,7 @@ type (
 		Password string `json:"password,omitempty"`
 		SSHKey   string `json:"ssh_key,omitempty"`
 		SFTPDir  string `json:"sftp_dir,omitempty"`
+		Dir      string `json:"current_dir,omitempty"`
 	}
 
 	// Step defines a pipeline step.


### PR DESCRIPTION
An optional parameter **«current_dir»** has been added to the server section, which sets the working directory (by default for linux - **«/tmp»**, for windows - **«C:\Windows\Temp»**. Example pipeline configuration:

```yaml
kind: pipeline
type: ssh
name: default

server:
  host: 1.2.3.4
  user: admin
  sftp_dir: /home/admin # Optional
  current_dir: drone    # Optional
  password:
    from_secret: password

steps:
- name: greeting
  commands:
  - echo hello world
```
